### PR TITLE
fix: map host port

### DIFF
--- a/localstack/start.go
+++ b/localstack/start.go
@@ -22,6 +22,8 @@ const (
 	defaultImage = "localstack/localstack"
 	// the single service port that LocalStack exposes by default
 	entryPort = "4566/tcp"
+	// the host port we bind to the entry port
+	hostPort = "4566"
 	// how long we’ll wait for pull+create operations
 	operationTimeout = 2 * time.Minute
 )
@@ -31,6 +33,7 @@ type Runner struct {
 	Cli          *client.Client
 	ImageURL     string
 	Image        string
+	HostPort     string
 	PortBindings nat.PortMap
 }
 
@@ -48,6 +51,7 @@ func NewRunner(cli *client.Client) (*Runner, error) {
 		Cli:          cli,
 		ImageURL:     defaultImageURL,
 		Image:        defaultImage,
+		HostPort:     hostPort,
 		PortBindings: buildPortBindings(),
 	}, nil
 }
@@ -55,7 +59,7 @@ func NewRunner(cli *client.Client) (*Runner, error) {
 // buildPortBindings automatically generates the port bindings for LocalStack.
 func buildPortBindings() nat.PortMap {
 	pm := nat.PortMap{
-		entryPort: {{HostIP: "127.0.0.1", HostPort: ""}}, // let Docker assign
+		entryPort: {{HostIP: "127.0.0.1", HostPort: hostPort}},
 	}
 	return pm
 }


### PR DESCRIPTION
This pull request updates the LocalStack runner to explicitly bind the LocalStack service port to a fixed host port, improving reliability and predictability when connecting to the service. The changes add a new `HostPort` field to the `Runner` struct and ensure that the port binding uses this fixed value.

Port binding enhancements:

* Added a `hostPort` constant (`"4566"`) and updated the port binding logic in `buildPortBindings()` to always bind LocalStack's internal port to this host port, instead of letting Docker assign a random port. [[1]](diffhunk://#diff-6dc68f0812562a9fb50d134b80ed95a817afea8f077cf250469709642e2423bcR25-R26) [[2]](diffhunk://#diff-6dc68f0812562a9fb50d134b80ed95a817afea8f077cf250469709642e2423bcR54-R62)

Runner struct improvements:

* Added a `HostPort` field to the `Runner` struct and set it during initialization in `NewRunner()`, ensuring the assigned port is tracked and available for use. [[1]](diffhunk://#diff-6dc68f0812562a9fb50d134b80ed95a817afea8f077cf250469709642e2423bcR36) [[2]](diffhunk://#diff-6dc68f0812562a9fb50d134b80ed95a817afea8f077cf250469709642e2423bcR54-R62)